### PR TITLE
Make errno accesses thread safe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,7 @@ name = "libnet"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "cfg-if",
  "colored",
  "dlpi",
  "libc",

--- a/libnet/Cargo.toml
+++ b/libnet/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 colored = "2"
+cfg-if = "1.0"
 tracing = "0.1"
 thiserror = "1"
 libc = "0.2"

--- a/libnet/src/ioctl.rs
+++ b/libnet/src/ioctl.rs
@@ -1423,7 +1423,7 @@ pub(crate) fn create_vnic(
         arg.mac_addr[1] = 0x08;
         arg.mac_addr[2] = 0x20;
 
-        sys::errno = 0;
+        sys::clear_errno();
         rioctl!(fd, sys::VNIC_IOC_CREATE, &arg)?;
 
         crate::link::get_link(id)

--- a/libnet/src/route.rs
+++ b/libnet/src/route.rs
@@ -44,7 +44,10 @@ pub fn get_routes() -> Result<Vec<Route>, Error> {
     unsafe {
         let sfd = socket(AF_ROUTE as i32, SOCK_RAW as i32, AF_UNSPEC as i32);
         if sfd < 0 {
-            return Err(Error::SystemError(format!("socket: {}", sys::errno)));
+            return Err(Error::SystemError(format!(
+                "socket: {}",
+                sys::errno()
+            )));
         }
 
         let req = rt_msghdr::default();
@@ -58,7 +61,7 @@ pub fn get_routes() -> Result<Vec<Route>, Error> {
             return Err(Error::SystemError(format!(
                 "write: {} {}",
                 n,
-                sys::errno
+                sys::errno()
             )));
         }
 
@@ -199,7 +202,10 @@ fn mod_route(
     unsafe {
         let sfd = socket(AF_ROUTE as i32, SOCK_RAW as i32, AF_UNSPEC as i32);
         if sfd < 0 {
-            return Err(Error::SystemError(format!("socket: {}", sys::errno)));
+            return Err(Error::SystemError(format!(
+                "socket: {}",
+                sys::errno()
+            )));
         }
 
         let mut msglen = size_of::<rt_msghdr>();
@@ -348,9 +354,9 @@ fn mod_route(
             }
         };
 
-        sys::errno = 0;
+        sys::clear_errno();
         let n = write(sfd, buf.as_ptr() as *const c_void, buf.len());
-        if sys::errno != 0 {
+        if sys::errno() != 0 {
             return Err(Error::SystemError(sys::errno_string()));
         }
         if n < buf.len() as isize {

--- a/libnet/src/sys.rs
+++ b/libnet/src/sys.rs
@@ -623,7 +623,7 @@ pub fn err_string(err: i32) -> String {
 
     // Either `strerror_r` or conversion to a a UTF8 string failed; fall back
     // to a message that just includes the error number
-    format!("unknown failure (errno {err})")
+    format!("unknown failure (errno {})", err)
 }
 
 pub type kstat_ctl_t = kstat_ctl;

--- a/libnet/src/sys.rs
+++ b/libnet/src/sys.rs
@@ -578,25 +578,52 @@ pub const IPMGMT_PROPS_ONLY: u32 = 0x00000020;
 pub const IPMGMT_UPDATE_IF: u32 = 0x00000040;
 pub const IPMGMT_UPDATE_IPMP: u32 = 0x00000080;
 
-extern "C" {
-    pub static mut errno: ::std::os::raw::c_int;
-    pub fn strerror(errnum: i32) -> *mut std::os::raw::c_char;
+fn errno_ptr() -> *mut c_int {
+    cfg_if::cfg_if! {
+        if #[cfg(target_os = "illumos")] {
+            unsafe { libc::___errno() }
+        } else if #[cfg(target_os = "linux")] {
+            unsafe { libc::__errno_location() }
+        } else {
+            compile_fail!("only linux and illumos are currently supported")
+        }
+    }
+}
+
+pub fn errno() -> c_int {
+    unsafe { *errno_ptr() }
+}
+
+pub fn clear_errno() {
+    unsafe {
+        *errno_ptr() = 0;
+    }
 }
 
 pub fn errno_string() -> String {
-    let s = unsafe { std::ffi::CStr::from_ptr(strerror(errno)) };
-    match s.to_str() {
-        Err(_) => "".to_string(),
-        Ok(s) => s.to_string(),
-    }
+    err_string(errno())
 }
 
 pub fn err_string(err: i32) -> String {
-    let s = unsafe { std::ffi::CStr::from_ptr(strerror(err)) };
-    match s.to_str() {
-        Err(_) => "".to_string(),
-        Ok(s) => s.to_string(),
+    // We could attempt to grow `buf` if we get back `ERANGE`, but (a) 128 bytes
+    // is probably more than enought and (b) if we fail we have a fallback plan
+    // anyway.
+    let mut buf = [0; 128];
+    let ret = unsafe { libc::strerror_r(err, buf.as_mut_ptr(), buf.len()) };
+    if ret == 0 {
+        // TODO-cleanup We could use `CStr::from_bytes_until_nul()` to avoid
+        // this `unsafe` block once it's stabilized. For now, `buf` contains
+        // many nul bytes (after the one added by `strerror_r`, so we'll use
+        // `CStr::from_ptr()` to search for the first nul.
+        let cstr = unsafe { std::ffi::CStr::from_ptr(buf.as_ptr()) };
+        if let Ok(s) = cstr.to_str() {
+            return s.to_string();
+        }
     }
+
+    // Either `strerror_r` or conversion to a a UTF8 string failed; fall back
+    // to a message that just includes the error number
+    format!("unknown failure (errno {err})")
 }
 
 pub type kstat_ctl_t = kstat_ctl;


### PR DESCRIPTION
We've seen of threads racing and seeing incorrect errno values; e.g.,

```
route error: system error short write: -1 < 172
```

implying [we saw write return -1 without setting errno](https://github.com/oxidecomputer/netadm-sys/blob/3e2d8b3f5e7e7eea61424ffbca494af12a930631/libnet/src/route.rs#L351-L362). This PR replaces the extern errno const with the use of [libc::___errno()](https://rust-lang.github.io/libc/x86_64-unknown-illumos/doc/libc/fn.___errno.html) (on illumos) or [libc::__errno_location()](https://rust-lang.github.io/libc/x86_64-unknown-linux-gnu/doc/libc/fn.__errno_location.html) (on linux). It also reworks the conversion of error numbers to strings to (a) use `strerror_r` over `strerror` and (b) fall back to a message that includes the error number if conversion to a string via libc fails.