### PR TITLE
support setting mac on vnic creation

### DIFF
--- a/.github/buildomat/jobs/build-and-test.sh
+++ b/.github/buildomat/jobs/build-and-test.sh
@@ -2,8 +2,8 @@
 #:
 #: name = "build-and-test"
 #: variety = "basic"
-#: target = "helios-20220404"
-#: rust_toolchain = "nightly-2021-09-03"
+#: target = "helios"
+#: rust_toolchain = "stable"
 #: output_rules = [
 #:   "/work/debug/*",
 #:   "/work/release/*",
@@ -29,7 +29,7 @@ done
 
 banner check
 cargo fmt -- --check
-cargo clippy
+cargo clippy -- --deny warnings
 
 banner pre-test
 uname -a

--- a/libnet/src/ioctl.rs
+++ b/libnet/src/ioctl.rs
@@ -1541,6 +1541,9 @@ pub(crate) fn create_vnic(
         };
         match mac {
             None => {
+                // This seems to be the OUI prefix used for bhyve/virtio NICs
+                // but I cannot find a documentation reference that actually
+                // says so.
                 arg.mac_addr[0] = 0x02;
                 arg.mac_addr[1] = 0x08;
                 arg.mac_addr[2] = 0x20;

--- a/libnet/src/ioctl.rs
+++ b/libnet/src/ioctl.rs
@@ -1510,6 +1510,7 @@ impl Default for VnicIocCreate {
 pub(crate) fn create_vnic(
     id: u32,
     link_id: u32,
+    mac: Option<Vec<u8>>,
 ) -> Result<crate::LinkInfo, Error> {
     unsafe {
         let fd = dld_fd()?;
@@ -1519,9 +1520,18 @@ pub(crate) fn create_vnic(
         let mut arg = VnicIocCreate {
             link_id,
             vnic_id: id,
-            mac_addr_type: VnicMacAddrType::Auto,
-            mac_len: 0,
-            mac_prefix_len: 3,
+            mac_addr_type: match mac {
+                None => VnicMacAddrType::Auto,
+                Some(_) => VnicMacAddrType::Fixed,
+            },
+            mac_len: match &mac {
+                None => 0,
+                Some(mac) => mac.len() as u32,
+            },
+            mac_prefix_len: match mac {
+                None => 3,
+                Some(_) => 0,
+            },
             mac_slot: -1,
             vid: 0,
             vrid: 0,
@@ -1529,9 +1539,21 @@ pub(crate) fn create_vnic(
             flags: 0,
             ..Default::default()
         };
-        arg.mac_addr[0] = 0x02;
-        arg.mac_addr[1] = 0x08;
-        arg.mac_addr[2] = 0x20;
+        match mac {
+            None => {
+                arg.mac_addr[0] = 0x02;
+                arg.mac_addr[1] = 0x08;
+                arg.mac_addr[2] = 0x20;
+            }
+            Some(mac) => {
+                if mac.len() > 20 {
+                    return Err(Error::BadArgument("mac too long".to_string()));
+                }
+                for (i, x) in mac.iter().enumerate() {
+                    arg.mac_addr[i] = *x;
+                }
+            }
+        };
 
         sys::clear_errno();
         rioctl!(fd, sys::VNIC_IOC_CREATE, &arg)?;

--- a/libnet/src/lib.rs
+++ b/libnet/src/lib.rs
@@ -66,7 +66,7 @@ pub enum Error {
 // Datalink management --------------------------------------------------------
 
 /// Link flags specifiy if a link is active, persistent, or both.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(u32)]
 pub enum LinkFlags {
     Active = 0x1,
@@ -92,7 +92,7 @@ impl Display for LinkFlags {
 }
 
 /// Link class specifies the type of datalink.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 #[repr(C)]
 pub enum LinkClass {
     Phys = 0x01,
@@ -131,7 +131,7 @@ impl Display for LinkClass {
 }
 
 /// Link state indicates the carrier status of the link.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum LinkState {
     Unknown,
     Down,
@@ -155,7 +155,7 @@ impl Display for LinkState {
 }
 
 /// Information about a datalink.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct LinkInfo {
     pub id: u32,
     pub name: String,
@@ -339,7 +339,7 @@ pub fn connect_simnet_peers(
 // IP address management ------------------------------------------------------
 
 /// The state of an IP address in the kernel.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 #[repr(i32)]
 pub enum IpState {
     Disabled = 0,
@@ -351,7 +351,7 @@ pub enum IpState {
 }
 
 /// Information in the kernel about an IP address.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct IpInfo {
     pub ifname: String,
     pub index: i32,

--- a/libnet/src/lib.rs
+++ b/libnet/src/lib.rs
@@ -22,11 +22,13 @@ pub mod link;
 /// state.
 pub mod route;
 
+/// System-level machinery
+pub mod sys;
+
 mod ioctl;
 mod kstat;
 mod ndpd;
 mod nvlist;
-mod sys;
 
 /// Error variants returned by netadm_sys.
 #[derive(thiserror::Error, Debug)]
@@ -300,9 +302,10 @@ pub fn get_tfport_info(link: &LinkHandle) -> Result<TfportInfo, Error> {
 pub fn create_vnic_link(
     name: &str,
     link: &LinkHandle,
+    mac: Option<Vec<u8>>,
     flags: LinkFlags,
 ) -> Result<LinkInfo, Error> {
-    crate::link::create_vnic_link(name, link.id()?, flags)
+    crate::link::create_vnic_link(name, link.id()?, mac, flags)
 }
 
 /// Delete a data link identified by `handle`.

--- a/libnet/src/link.rs
+++ b/libnet/src/link.rs
@@ -451,10 +451,11 @@ pub(crate) fn create_tfport_link(
 pub fn create_vnic_link(
     name: &str,
     link: u32,
+    mac: Option<Vec<u8>>,
     flags: LinkFlags,
 ) -> Result<LinkInfo, Error> {
     let id = crate::link::create_link_id(name, LinkClass::Vnic, flags)?;
-    let link_info = match crate::ioctl::create_vnic(id, link) {
+    let link_info = match crate::ioctl::create_vnic(id, link, mac) {
         Ok(l) => Ok(l),
         Err(e) => {
             let _ = delete_link_id(id, flags);

--- a/libnet/src/nvlist.rs
+++ b/libnet/src/nvlist.rs
@@ -99,7 +99,7 @@ pub enum Value<'a> {
 }
 
 #[allow(dead_code)]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 #[repr(i32)]
 pub enum NvDataType {
     DontCare = -1,

--- a/libnet/src/sys.rs
+++ b/libnet/src/sys.rs
@@ -248,6 +248,12 @@ impl strioctl {
     }
 }
 
+impl Default for strioctl {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 pub const LIFNAMSIZ: usize = 32;
 
 pub const DLDIOC_MACADDRGET: ioc_t = DLDIOC!(0x15);

--- a/libnet/tests/link.rs
+++ b/libnet/tests/link.rs
@@ -119,7 +119,7 @@ fn test_vnic_lifecycle() -> Result<()> {
         .into();
 
     // create vnic
-    let vnic0: DropLink = create_vnic_link(name, &sim0.handle(), flags)
+    let vnic0: DropLink = create_vnic_link(name, &sim0.handle(), None, flags)
         .expect("create vnic")
         .into();
 


### PR DESCRIPTION
This is a cherry pick from the `siocgnds` branch that Falcon has now come to depend on. This PR should free Falcon from dependence on `siocgnds`.