### PR TITLE
Use Option for MTU instead of 0 sentinel.

### DIFF
--- a/libnet/src/lib.rs
+++ b/libnet/src/lib.rs
@@ -161,7 +161,7 @@ pub struct LinkInfo {
     pub class: LinkClass,
     pub state: LinkState,
     pub mac: [u8; 6],
-    pub mtu: u32,
+    pub mtu: Option<u32>,
     pub over: u32,
 }
 

--- a/libnet/src/link.rs
+++ b/libnet/src/link.rs
@@ -197,10 +197,10 @@ pub(crate) fn get_link(id: u32) -> Result<LinkInfo, Error> {
     };
 
     let mtu = match crate::ioctl::get_mtu(id) {
-        Ok(mtu) => mtu,
+        Ok(mtu) => Some(mtu),
         Err(e) => {
             warn!("error fetching mtu on linkid {}: {}", id, e);
-            0
+            None
         }
     };
 

--- a/netadm/src/main.rs
+++ b/netadm/src/main.rs
@@ -461,10 +461,16 @@ fn show_links(_opts: &Opts, _s: &Show, _l: &ShowLinks) -> Result<()> {
             l.mac[0], l.mac[1], l.mac[2], l.mac[3], l.mac[4], l.mac[5],
         );
 
+        let mtu = if let Some(mtu) = l.mtu {
+            mtu.to_string()
+        } else {
+            "?".to_string()
+        };
+
         writeln!(
             &mut tw,
             "{}\t{}\t{}\t{}\t{}\t{}\t{}",
-            l.id, name, l.flags, l.class, l.state, macf, l.mtu,
+            l.id, name, l.flags, l.class, l.state, macf, mtu,
         )?;
     }
     tw.flush()?;


### PR DESCRIPTION
`DLDIOC_GETMACPROP` can fail in certain cases (e.g. https://www.illumos.org/issues/13992). Use an `Option` to better semantically represent this case.