### PR TITLE
Use helios-latest as CI buildomat target.

### DIFF
--- a/.github/buildomat/jobs/build-and-test.sh
+++ b/.github/buildomat/jobs/build-and-test.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "build-and-test"
 #: variety = "basic"
-#: target = "helios"
+#: target = "helios-latest"
 #: rust_toolchain = "stable"
 #: output_rules = [
 #:   "/work/debug/*",

--- a/libnet/Cargo.toml
+++ b/libnet/Cargo.toml
@@ -2,6 +2,7 @@
 name = "libnet"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.64"
 
 [dependencies]
 colored = "2"

--- a/libnet/src/ip.rs
+++ b/libnet/src/ip.rs
@@ -86,19 +86,14 @@ pub const LIFNAMSIZ: u32 = 32;
 pub const IPADM_AOBJ_USTRSIZ: u32 = 32;
 pub const IPADM_AOBJSIZ: u32 = LIFNAMSIZ + IPADM_AOBJ_USTRSIZ;
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Default, Copy, Clone)]
 #[repr(i32)]
 pub enum AddrType {
+    #[default]
     AddrNone,
     Static,
     Ipv6Addrconf,
     Dhcp,
-}
-
-impl Default for AddrType {
-    fn default() -> Self {
-        AddrType::AddrNone
-    }
 }
 
 #[repr(C)]

--- a/libnet/src/lib.rs
+++ b/libnet/src/lib.rs
@@ -1,5 +1,7 @@
 // Copyright 2021 Oxide Computer Company
 
+#![allow(clippy::uninlined_format_args)]
+
 use colored::*;
 use std::collections::BTreeMap;
 use std::fmt::{Display, Formatter};

--- a/netadm/Cargo.toml
+++ b/netadm/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "netadm"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.64"
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
Unfortunately cargo 1.67 [panics](https://github.com/rust-lang/cargo/issues/11629) on illumos when stdout is not a tty. It's fixed upstream but not on current stable. There is also a change on the illumos side that addresses this (isatty wasn't setting errno). Changing the buildomat target here to helios-latest pulls in the illumos side fix.