### PR TITLE
Fix ioctl rw ub

### DIFF
--- a/.github/buildomat/jobs/build-and-test.sh
+++ b/.github/buildomat/jobs/build-and-test.sh
@@ -29,7 +29,7 @@ done
 
 banner check
 cargo fmt -- --check
-cargo clippy -- --deny warnings
+cargo clippy --all-targets -- --deny warnings
 
 banner pre-test
 uname -a

--- a/.github/buildomat/jobs/build-and-test.sh
+++ b/.github/buildomat/jobs/build-and-test.sh
@@ -38,6 +38,7 @@ uname -a
 
 banner test
 pfexec ptime -m cargo test
+pfexec ptime -m cargo test --release
 
 banner post-test
 ./target/debug/netadm show links

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: 1.70.0
           targets: x86_64-unknown-illumos
 
       - name: generate documentation

--- a/libnet/tests/ip.rs
+++ b/libnet/tests/ip.rs
@@ -100,10 +100,10 @@ fn test_v6_local_lifecycle() -> Result<()> {
         .into();
 
     // enable link-local
-    enable_v6_link_local("lnt_v6ls_sim3", "v6").expect("enable link local");
+    enable_v6_link_local("lnt_v6ls_sim3", "ll").expect("enable link local");
 
     // ask for address we just created and check equivalence
-    let addr: DropIp = get_ipaddr_info("lnt_v6ls_sim3/v6")
+    let addr: DropIp = get_ipaddr_info("lnt_v6ls_sim3/ll")
         .expect("get info")
         .into();
 
@@ -115,7 +115,7 @@ fn test_v6_local_lifecycle() -> Result<()> {
 
     drop(addr);
 
-    get_ipaddr_info("lnt_v6ls_sim3/v6").expect_err("zombie addr");
+    get_ipaddr_info("lnt_v6ls_sim3/ll").expect_err("zombie addr");
 
     drop(sim0);
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.70.0"


### PR DESCRIPTION
There are many places in the code where we call `libc::ioctl` using an immutable reference that is modified by the underlying `ioctl` call. This is undefined behavior, and it finally caught up with us in Rust 1.70. The libnet code uses a constrained form of `ioctl` with only one argument. This PR adds a wrapper around `libc::ioctl` to ensure that a mutable reference/pointer is being used. For operations that do not modify data (`SIOCS...` "set" operations) an `ioctl_ro` and `rioctl_ro` macro is provided to explicitly opt-in to use of immutable references.