### PR TITLE
add timeout to route-get

### DIFF
--- a/netadm/src/main.rs
+++ b/netadm/src/main.rs
@@ -584,7 +584,7 @@ fn show_addrs(_opts: &Opts, _s: &Show, a: &ShowAddrs) -> Result<()> {
 }
 
 fn show_a_route(_opts: &Opts, _s: &Show, sr: &ShowRoute) -> Result<()> {
-    let route = route::get_route(sr.destination)?;
+    let route = route::get_route(sr.destination, None)?;
     println!("{:#?}", route);
     Ok(())
 }


### PR DESCRIPTION
After sending an router socket message to the kernel, it's possible we may not get a reply. Add the option for callers to specify a read timeout on the AF_SOCKET so they are not forced into waiting forever in these cases.