### PR TITLE
basic tcp-md5/pf_key support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,7 +437,7 @@ dependencies = [
  "oxnet",
  "rand",
  "rusty-doors",
- "socket2",
+ "socket2 0.5.7",
  "thiserror",
  "tracing",
 ]
@@ -880,6 +880,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -959,7 +969,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.4.9",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -1202,6 +1212,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1233,6 +1252,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,10 +1280,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1275,10 +1322,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1299,6 +1364,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1311,10 +1382,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
 dependencies = [
  "gimli",
 ]
@@ -16,6 +16,21 @@ name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -37,16 +52,16 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.3.2"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
- "is-terminal",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
@@ -58,9 +73,9 @@ checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.0"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
 dependencies = [
  "utf8parse",
 ]
@@ -76,42 +91,31 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.2"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
 dependencies = [
  "anstyle",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.71"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
 dependencies = [
  "addr2line",
  "cc",
@@ -124,27 +128,36 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bumpalo"
-version = "3.12.1"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "68064e60dbf1f17005c2fde4d07c16d8baa506fd7ffed8ccab702d93617975c7"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -154,90 +167,77 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.24"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
- "num-integer",
  "num-traits",
- "winapi",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "clap"
-version = "4.2.7"
+version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
+checksum = "11d8838454fda655dafd3accb2b6e2bea645b9e4078abe84a22ceb947235c5cc"
 dependencies = [
  "clap_builder",
  "clap_derive",
- "once_cell",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.2.7"
+version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
+checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags",
  "clap_lex",
  "strsim",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.2.0"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
+checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.74",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.4.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
-
-[[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width",
-]
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "colored"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
 dependencies = [
- "atty",
  "lazy_static",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.4"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cstr-argument"
@@ -247,50 +247,6 @@ checksum = "b6bd9c8e659a473bce955ae5c35b116af38af11a7acb0b480e01f3ed348aeb40"
 dependencies = [
  "cfg-if",
  "memchr",
-]
-
-[[package]]
-name = "cxx"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
-dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2",
- "quote",
- "scratch",
- "syn 2.0.66",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
 ]
 
 [[package]]
@@ -313,14 +269,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
-name = "errno"
-version = "0.3.9"
+name = "equivalent"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "foreign-types"
@@ -340,7 +292,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -350,46 +302,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
-name = "gimli"
-version = "0.28.1"
+name = "getrandom"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "gimli"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "humantime"
@@ -399,47 +344,35 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.56"
+version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows",
+ "windows-core",
 ]
 
 [[package]]
 name = "iana-time-zone-haiku"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
- "cxx",
- "cxx-build",
+ "cc",
 ]
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
 dependencies = [
- "autocfg",
+ "equivalent",
  "hashbrown",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi 0.3.1",
- "libc",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -452,37 +385,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.7"
+name = "is_terminal_polyfill"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
-dependencies = [
- "hermit-abi 0.3.1",
- "io-lifetimes",
- "rustix",
- "windows-sys 0.48.0",
-]
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -508,6 +435,7 @@ dependencies = [
  "nvpair",
  "nvpair-sys",
  "oxnet",
+ "rand",
  "rusty-doors",
  "socket2",
  "thiserror",
@@ -515,25 +443,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "link-cplusplus"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
-
-[[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -541,12 +454,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "matchers"
@@ -554,14 +464,14 @@ version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "miniz_oxide"
@@ -574,14 +484,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.6"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
+ "hermit-abi",
  "libc",
- "log",
  "wasi",
- "windows-sys 0.45.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -601,32 +511,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
-dependencies = [
- "hermit-abi 0.2.6",
- "libc",
 ]
 
 [[package]]
@@ -667,23 +557,23 @@ source = "git+https://github.com/jmesmon/rust-libzfs?branch=master#ecd5a922247a6
 
 [[package]]
 name = "object"
-version = "0.32.2"
+version = "0.36.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "oxnet"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/oxnet#2612d2203effcfdcbf83778a77f1bfd03fe6ed24"
+source = "git+https://github.com/oxidecomputer/oxnet#7dacd265f1bcd0f8b47bd4805250c4f0812da206"
 dependencies = [
  "ipnetwork",
  "schemars",
@@ -693,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -703,15 +593,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.7"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys 0.45.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -719,6 +609,15 @@ name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "pretty-hex"
@@ -738,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -755,21 +654,54 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.2.16"
+name = "rand"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.8.1"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
- "regex-syntax 0.7.1",
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -782,6 +714,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.4",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,9 +732,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.1"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "rustc-demangle"
@@ -800,23 +743,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
-name = "rustix"
-version = "0.37.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
-dependencies = [
- "bitflags",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "rusty-doors"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/rusty-doors#42ad0104095425eea76934b5d735b4c6a438ef66"
+source = "git+https://github.com/oxidecomputer/rusty-doors#0e3a1495dcf8b7b5e11a6921c2cf1cf957c5a5bf"
 dependencies = [
  "libc",
  "rusty-doors-macros",
@@ -825,7 +754,7 @@ dependencies = [
 [[package]]
 name = "rusty-doors-macros"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/rusty-doors#42ad0104095425eea76934b5d735b4c6a438ef66"
+source = "git+https://github.com/oxidecomputer/rusty-doors#0e3a1495dcf8b7b5e11a6921c2cf1cf957c5a5bf"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -833,9 +762,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "schemars"
@@ -858,39 +787,33 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.66",
+ "syn 2.0.74",
 ]
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "scratch"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.203"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.203"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -901,43 +824,50 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.74",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.4"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.1"
+name = "shlex"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
@@ -951,9 +881,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -968,9 +898,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.66"
+version = "2.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -979,49 +909,38 @@ dependencies = [
 
 [[package]]
 name = "tabwriter"
-version = "1.2.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36205cfc997faadcc4b0b87aaef3fbedafe20d38d4959a7ca6ff803564051111"
+checksum = "a327282c4f64f6dc37e3bba4c2b6842cc3a992f204fa58d917696a89f691e5f6"
 dependencies = [
- "lazy_static",
- "regex",
  "unicode-width",
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.74",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1029,45 +948,44 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.30.0"
+version = "1.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d3ce25f50619af8b0aec2eb23deebe84249e19e2ddd393a6e16e3300a6dadfd"
+checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.74",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.1"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.8"
+version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -1076,11 +994,10 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1088,20 +1005,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.24"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.74",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.30"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
@@ -1109,12 +1026,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
 dependencies = [
- "lazy_static",
  "log",
+ "once_cell",
  "tracing-core",
 ]
 
@@ -1152,21 +1069,21 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.10"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"
@@ -1182,34 +1099,35 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.74",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1217,22 +1135,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.74",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "winapi"
@@ -1251,36 +1169,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.48.0"
+name = "windows-core"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.48.0",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1289,7 +1189,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -1303,32 +1203,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -1349,15 +1234,9 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1367,15 +1246,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1385,15 +1258,9 @@ checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1409,15 +1276,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1427,15 +1288,9 @@ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1445,15 +1300,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1463,15 +1312,9 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1481,9 +1324,30 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.4.6"
+version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.74",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,6 +440,7 @@ dependencies = [
  "socket2 0.5.7",
  "thiserror",
  "tracing",
+ "winnow 0.6.18",
 ]
 
 [[package]]
@@ -999,7 +1000,7 @@ checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap",
  "toml_datetime",
- "winnow",
+ "winnow 0.4.6",
 ]
 
 [[package]]
@@ -1410,6 +1411,15 @@ name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,7 +437,7 @@ dependencies = [
  "oxnet",
  "rand",
  "rusty-doors",
- "socket2 0.5.7",
+ "socket2",
  "thiserror",
  "tracing",
  "winnow 0.6.18",
@@ -881,16 +881,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "socket2"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -970,7 +960,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.4.9",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -1000,7 +990,7 @@ checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap",
  "toml_datetime",
- "winnow 0.4.6",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -1213,15 +1203,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1253,22 +1234,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1281,22 +1246,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1323,28 +1276,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1365,12 +1300,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1383,22 +1312,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/libnet/Cargo.toml
+++ b/libnet/Cargo.toml
@@ -24,3 +24,4 @@ num_enum = "0.5.7"
 oxnet = { git = "https://github.com/oxidecomputer/oxnet" }
 rusty-doors = { git = "https://github.com/oxidecomputer/rusty-doors" }
 rand = "0.8.5"
+winnow = "0.6.18"

--- a/libnet/Cargo.toml
+++ b/libnet/Cargo.toml
@@ -23,3 +23,4 @@ dlpi = { git = "https://github.com/oxidecomputer/dlpi-sys" }
 num_enum = "0.5.7"
 oxnet = { git = "https://github.com/oxidecomputer/oxnet" }
 rusty-doors = { git = "https://github.com/oxidecomputer/rusty-doors" }
+rand = "0.8.5"

--- a/libnet/src/lib.rs
+++ b/libnet/src/lib.rs
@@ -27,6 +27,9 @@ pub mod route;
 /// System-level machinery
 pub mod sys;
 
+/// Functions for managing RFC2367 keys
+pub mod pf_key;
+
 mod ioctl;
 mod kstat;
 mod ndpd;

--- a/libnet/src/pf_key.rs
+++ b/libnet/src/pf_key.rs
@@ -672,9 +672,9 @@ mod parse {
     pub fn header(buf: &mut &[u8]) -> PResult<Header> {
         Ok(Header {
             version: le_u8.parse_next(buf)?,
-            typ: parse::message_type.parse_next(buf)?,
+            typ: message_type.parse_next(buf)?,
             errno: le_u8.parse_next(buf)?,
-            sa_typ: parse::sa_type.parse_next(buf)?,
+            sa_typ: sa_type.parse_next(buf)?,
             len: le_u16.parse_next(buf)?,
             reserved: le_u16.parse_next(buf)?,
             seq: le_u32.parse_next(buf)?,
@@ -684,22 +684,21 @@ mod parse {
 
     pub fn extension(buf: &mut &[u8]) -> PResult<Extension> {
         let len = le_u16.parse_next(buf)?;
-        let typ = parse::sa_ext_type.parse_next(buf)?;
-        println!("{typ:?}");
+        let typ = sa_ext_type.parse_next(buf)?;
         Ok(match typ {
             SaExtType::Sa => {
-                Extension::Association(parse::association(len).parse_next(buf)?)
+                Extension::Association(association(len).parse_next(buf)?)
             }
             SaExtType::LifetimeCurrent
             | SaExtType::LifetimeHard
             | SaExtType::LifetimeSoft => {
-                Extension::Lifetime(parse::lifetime(len, typ).parse_next(buf)?)
+                Extension::Lifetime(lifetime(len, typ).parse_next(buf)?)
             }
             SaExtType::AddressSrc | SaExtType::AddressDst => {
-                Extension::Address(parse::address(len, typ).parse_next(buf)?)
+                Extension::Address(address(len, typ).parse_next(buf)?)
             }
             SaExtType::StrAuth => {
-                Extension::StrAuth(parse::str_auth(len).parse_next(buf)?)
+                Extension::StrAuth(str_auth(len).parse_next(buf)?)
             }
         })
     }
@@ -713,9 +712,9 @@ mod parse {
                 typ: SaExtType::Sa,
                 spi: le_u32.parse_next(buf)?,
                 replay: le_u8.parse_next(buf)?,
-                state: parse::sa_state.parse_next(buf)?,
-                auth: parse::sa_auth_type.parse_next(buf)?,
-                encrypt: parse::sa_encrypt_type.parse_next(buf)?,
+                state: sa_state.parse_next(buf)?,
+                auth: sa_auth_type.parse_next(buf)?,
+                encrypt: sa_encrypt_type.parse_next(buf)?,
                 flags: le_u32.parse_next(buf)?,
             })
         }

--- a/libnet/src/pf_key.rs
+++ b/libnet/src/pf_key.rs
@@ -1,16 +1,28 @@
 // Copyright 2024 Oxide Computer Company
 
+// This file implements the PF_KEY protocol as described in RFC 2367.
+
 use libc::IPPROTO_TCP;
+use num_enum::{IntoPrimitive, TryFromPrimitive};
 use socket2::{Domain, Protocol, SockAddr, Socket, Type};
 use std::io::{Read, Write};
+use std::net::SocketAddr;
 use std::{mem::size_of, time::Duration};
+use winnow::binary::{le_u16, le_u32, le_u64, le_u8};
+use winnow::combinator::repeat;
+use winnow::error::{ContextError, ErrMode};
+use winnow::token::take;
+use winnow::{PResult, Parser};
 
+/// The PF_KEY protocol family.
 const PF_KEY: i32 = 27;
+/// The PF_KEY protocol version.
 const PF_KEY_V2: u8 = 2;
-//const MAX_KEY_SIZE: usize = (u16::MAX >> 8) as usize;
-const MAX_KEY_SIZE: usize = 80;
+/// Maximum size of a StrAuth key.
+const MAX_STR_AUTH_KEY_SIZE: usize = 80;
 
-#[derive(Debug)]
+/// PF_KEY message types.
+#[derive(Debug, IntoPrimitive, TryFromPrimitive, Copy, Clone)]
 #[repr(u8)]
 pub enum MessageType {
     Reserved = 0,
@@ -31,7 +43,8 @@ pub enum MessageType {
     DelPairState = 15,
 }
 
-#[derive(Debug)]
+/// PF_KEY security association types.
+#[derive(Debug, IntoPrimitive, TryFromPrimitive, Copy, Clone)]
 #[repr(u8)]
 pub enum SaType {
     Unspec = 0,
@@ -44,6 +57,8 @@ pub enum SaType {
     Mip = 8,
 }
 
+/// PF_KEY security association extension types.
+#[derive(Debug, IntoPrimitive, TryFromPrimitive, Copy, Clone)]
 #[repr(u16)]
 pub enum SaExtType {
     Sa = 1,
@@ -52,30 +67,32 @@ pub enum SaExtType {
     LifetimeSoft = 4,
     AddressSrc = 5,
     AddressDst = 6,
-    AddressProxy = 7,
-    KeyAuth = 8,
-    KeyEncrypt = 9,
-    IdentitySrc = 10,
-    IdentityDst = 11,
-    Sensitivity = 12,
-    Proposal = 13,
-    SupportedAuth = 14,
-    SupportedEncrypt = 15,
-    SpiRange = 16,
-    Ereg = 17,
-    Eprop = 18,
-    KmCookie = 19,
-    AddressNattLoc = 20,
-    AddressNattRem = 21,
-    AddressInnerDst = 22,
-    Pair = 23,
-    ReplayValue = 24,
-    Edump = 25,
-    LifetimeIdle = 26,
-    OuterSens = 27,
+    //TODO AddressProxy = 7,
+    //TODO KeyAuth = 8,
+    //TODO KeyEncrypt = 9,
+    //TODO IdentitySrc = 10,
+    //TODO IdentityDst = 11,
+    //TODO Sensitivity = 12,
+    //TODO Proposal = 13,
+    //TODO SupportedAuth = 14,
+    //TODO SupportedEncrypt = 15,
+    //TODO SpiRange = 16,
+    //TODO Ereg = 17,
+    //TODO Eprop = 18,
+    //TODO KmCookie = 19,
+    //TODO AddressNattLoc = 20,
+    //TODO AddressNattRem = 21,
+    //TODO AddressInnerDst = 22,
+    //TODO Pair = 23,
+    //TODO ReplayValue = 24,
+    //TODO Edump = 25,
+    //TODO LifetimeIdle = 26,
+    //TODO OuterSens = 27,
     StrAuth = 28,
 }
 
+/// PF_KEY security association authentication types.
+#[derive(Debug, IntoPrimitive, TryFromPrimitive, Copy, Clone)]
 #[repr(u8)]
 pub enum SaAuthType {
     None,
@@ -87,6 +104,8 @@ pub enum SaAuthType {
     Sha512Hmac,
 }
 
+/// PF_KEY security association encryption types.
+#[derive(Debug, IntoPrimitive, TryFromPrimitive, Copy, Clone)]
 #[repr(u8)]
 pub enum SaEncryptType {
     None,
@@ -103,6 +122,8 @@ pub enum SaEncryptType {
     AesGcm16,
 }
 
+/// PF_KEY security association states.
+#[derive(Debug, IntoPrimitive, TryFromPrimitive, Copy, Clone)]
 #[repr(u8)]
 pub enum SaState {
     Larval,
@@ -111,78 +132,355 @@ pub enum SaState {
     Dead,
 }
 
+/// A PF_KEY security association header.
+#[derive(Debug)]
 #[repr(C, packed)]
 pub struct Header {
+    /// Protocol version. Always PF_KEY_2.
     pub version: u8,
+    /// The message type.
     pub typ: MessageType,
+    /// Error returned by OS, if any.
     pub errno: u8,
+    /// Security association type.
     pub sa_typ: SaType,
+    /// Length of the message in 8-byte units.
     pub len: u16,
+    /// Reserved when going to the kernel, diagnostic code when coming from the
+    /// kernel.
     pub reserved: u16,
+    /// Sequence id for this message.
     pub seq: u32,
+    /// Process id of the sender.
     pub pid: u32,
 }
 
+impl Header {
+    fn new(typ: MessageType, sa_typ: SaType, len: usize) -> Self {
+        Header {
+            version: PF_KEY_V2,
+            typ,
+            errno: 0,
+            sa_typ,
+            len: u16::try_from(len).unwrap() >> 3,
+            reserved: 0,
+            seq: rand::random(),
+            pid: std::process::id(),
+        }
+    }
+}
+
+/// The extension enumeration contains all PF_KEY extensions supported by this
+/// module.
+#[derive(Debug)]
+pub enum Extension {
+    Association(Association),
+    Lifetime(Lifetime),
+    Address(Address),
+    StrAuth(StrAuth),
+}
+
+/// Basic information about a security association.
+#[derive(Clone, Copy, Debug)]
 #[repr(C, packed)]
 pub struct Association {
+    /// Length of this extension in 8-byte units.
     pub len: u16,
+    /// The type of this extension.
     pub typ: SaExtType,
+    /// Security parameters index.
     pub spi: u32,
+    /// Replay window size.
     pub replay: u8,
+    /// State of the association.
     pub state: SaState,
+    /// Authentication type.
     pub auth: SaAuthType,
+    /// Encryption type.
     pub encrypt: SaEncryptType,
+    /// Optional flags.
     pub flags: u32,
 }
 
+impl Default for Association {
+    fn default() -> Self {
+        Association {
+            len: u16::try_from(size_of::<Association>()).unwrap() >> 3,
+            typ: SaExtType::Sa,
+            spi: 0, // This is not for IPsec
+            replay: 0,
+            state: SaState::Mature,
+            auth: SaAuthType::Md5,
+            encrypt: SaEncryptType::None,
+            flags: 0,
+        }
+    }
+}
+
+/// Lifetime information for a security association.
+#[derive(Debug)]
 #[repr(C, packed)]
 pub struct Lifetime {
+    /// Length of this extension in 8-byte units.
     pub len: u16,
+    /// The type of this extension.
     pub typ: SaExtType,
+    /// How many allocations this lifetime lasts for.
     pub alloc: u32,
+    /// How many bytes this lifetime lasts for.
     pub bytes: u64,
+    /// How long after creation this lifetime expires in seconds.
     pub addtime: u64,
+    /// How long after first use this lifetime expires in seconds.
     pub usetime: u64,
 }
 
+impl Lifetime {
+    fn new(addtime: Duration, usetime: Duration) -> Self {
+        Lifetime {
+            len: u16::try_from(size_of::<Lifetime>()).unwrap() >> 3,
+            typ: SaExtType::LifetimeHard,
+            alloc: 0, // no allocation limit
+            bytes: 0, // no byte limit
+            addtime: addtime.as_secs(),
+            usetime: usetime.as_secs(),
+        }
+    }
+}
+
+/// Address information for a security association.
 #[repr(C, packed)]
 pub struct Address {
+    /// Length of this extension in 8-byte units.
     pub len: u16,
+    /// The type of this extension.
     pub typ: SaExtType,
+    /// Protocol family identifier for this address.
     pub proto: u8,
+    /// Prefix length associated with the address.
     pub prefix_len: u8,
+    /// Reserved bits.
     pub reserved: u16,
+    /// Address and port the security association binds to.
     pub sockaddr: SockAddr,
 }
 
-#[repr(C, packed)]
-pub struct Key {
-    pub len: u16,
-    pub typ: SaExtType,
-    pub bits: u16,
-    pub reserved: u16,
-    pub data: [u8; MAX_KEY_SIZE],
+impl std::fmt::Debug for Address {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = unsafe { (self as *const Address).read_unaligned() };
+        let len = s.len;
+        let typ = s.typ;
+        let proto = s.proto;
+        let plen = s.prefix_len;
+        let res = s.reserved;
+        let sa = s.sockaddr;
+        let sa = sa.as_socket();
+        f.debug_struct("Address")
+            .field("len", &len)
+            .field("typ", &typ)
+            .field("proto", &proto)
+            .field("prefix_len", &plen)
+            .field("reserved", &res)
+            .field("sockaddr", &sa)
+            .finish()
+    }
 }
 
+impl Address {
+    /// Create a new source address extension.
+    fn src(sockaddr: SockAddr, proto: u8) -> Self {
+        Self::new(sockaddr, proto, SaExtType::AddressSrc)
+    }
+
+    /// Create a new destination address extension.
+    fn dst(sockaddr: SockAddr, proto: u8) -> Self {
+        Self::new(sockaddr, proto, SaExtType::AddressDst)
+    }
+
+    /// Create a new address extension.
+    fn new(sockaddr: SockAddr, proto: u8, typ: SaExtType) -> Self {
+        Address {
+            len: u16::try_from(size_of::<Address>()).unwrap() >> 3,
+            typ,
+            proto,
+            prefix_len: 0,
+            reserved: 0,
+            sockaddr,
+        }
+    }
+
+    /// Get the socket address.
+    pub fn get_sockaddr(&self) -> Option<SocketAddr> {
+        let s = unsafe { (self as *const Address).read_unaligned() };
+        let sa = s.sockaddr;
+        sa.as_socket()
+    }
+}
+
+/// String authentication information for this security association.
+#[repr(C, packed)]
+pub struct StrAuth {
+    /// Length of this extension in 8-byte units.
+    pub len: u16,
+    /// The type of this extension.
+    pub typ: SaExtType,
+    /// Length of the key in bits.
+    pub bits: u16,
+    /// Reserved.
+    pub reserved: u16,
+    /// Key data.
+    pub data: [u8; MAX_STR_AUTH_KEY_SIZE],
+}
+
+impl std::fmt::Debug for StrAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = unsafe { (self as *const StrAuth).read_unaligned() };
+        let len = s.len;
+        let typ = s.typ;
+        let bits = s.bits;
+        let res = s.reserved;
+        let key = s.key();
+        f.debug_struct("StrAuth")
+            .field("len", &len)
+            .field("typ", &typ)
+            .field("bits", &bits)
+            .field("reserved", &res)
+            .field("data", &key)
+            .finish()
+    }
+}
+
+impl StrAuth {
+    /// Create a new string authentication extension for a given key.
+    fn new(authstring: &str) -> Self {
+        let mut key = StrAuth {
+            len: u16::try_from(size_of::<StrAuth>()).unwrap() >> 3,
+            typ: SaExtType::StrAuth,
+            bits: u16::try_from(authstring.len() << 3).unwrap(),
+            reserved: 0,
+            data: [0; MAX_STR_AUTH_KEY_SIZE],
+        };
+        key.data[..authstring.len()].copy_from_slice(authstring.as_bytes());
+        key
+    }
+
+    /// Return the key in string form.
+    pub fn key(&self) -> String {
+        let s = unsafe { (self as *const StrAuth).read_unaligned() };
+        let bits = s.bits;
+        let bytelen = (bits >> 3) as usize;
+        let data = s.data;
+        String::from_utf8_lossy(&data[..bytelen]).to_string()
+    }
+}
+
+/// A packet to add or update a TCP-MD5 security association.
 #[repr(C, packed)]
 pub struct TcpMd5SetKeyRequest {
+    /// Packet header.
     pub header: Header,
+    /// Association info.
     pub association: Association,
+    /// Lifetime info.
     pub lifetime: Lifetime,
+    /// Source socket address to bind to.
     pub src: Address,
+    /// Destination socket address to bind to.
     pub dst: Address,
-    pub key: Key,
+    /// String-based key.
+    pub key: StrAuth,
 }
 
+impl TcpMd5SetKeyRequest {
+    /// Create a new TCP-MD5 set key request.
+    fn new(
+        src: SockAddr,
+        dst: SockAddr,
+        authstring: &str,
+        valid_time: Duration,
+        update: bool,
+    ) -> Self {
+        let mtype = if update {
+            MessageType::Update
+        } else {
+            MessageType::Add
+        };
+
+        Self {
+            header: Header::new(mtype, SaType::TcpSig, size_of::<Self>()),
+            association: Association::default(),
+            lifetime: Lifetime::new(valid_time, valid_time),
+            src: Address::src(src, IPPROTO_TCP as u8),
+            dst: Address::dst(dst, IPPROTO_TCP as u8),
+            key: StrAuth::new(authstring),
+        }
+    }
+}
+
+/// A packet to delete a TCP-MD5 security association.
 #[repr(C, packed)]
 pub struct TcpMd5DeleteKeyRequest {
+    /// Packet header.
     pub header: Header,
+    /// Association info.
     pub association: Association,
+    /// Source socket address to unbind.
     pub src: Address,
+    /// Destination socket address to unbind.
     pub dst: Address,
 }
 
-/// Add a TCP-MD5 security association for the provided souce and destination
+impl TcpMd5DeleteKeyRequest {
+    fn new(src: SockAddr, dst: SockAddr) -> Self {
+        Self {
+            header: Header::new(
+                MessageType::Delete,
+                SaType::TcpSig,
+                size_of::<Self>(),
+            ),
+            association: Association::default(),
+            src: Address::src(src, IPPROTO_TCP as u8),
+            dst: Address::dst(dst, IPPROTO_TCP as u8),
+        }
+    }
+}
+
+/// A packet to request info about a TCP-MD5 security association.
+#[repr(C, packed)]
+pub struct TcpMd5GetKeyRequest {
+    /// Packet header.
+    pub header: Header,
+    /// Association info.
+    pub association: Association,
+    /// Source socket address predicate.
+    pub src: Address,
+    /// Destination socket address predicate.
+    pub dst: Address,
+}
+
+impl TcpMd5GetKeyRequest {
+    fn new(src: SockAddr, dst: SockAddr) -> Self {
+        Self {
+            header: Header::new(
+                MessageType::Get,
+                SaType::TcpSig,
+                size_of::<Self>(),
+            ),
+            association: Association::default(),
+            src: Address::src(src, IPPROTO_TCP as u8),
+            dst: Address::dst(dst, IPPROTO_TCP as u8),
+        }
+    }
+}
+
+/// Response information returned from kernel from a key association request.
+#[derive(Debug)]
+pub struct GetAssociationResponse {
+    pub header: Header,
+    pub extensions: Vec<Extension>,
+}
+
+/// Add a TCP-MD5 security association for the provided source and destination
 /// address with `authstring` as the key that is valid for `valid_time` after
 /// creation.
 pub fn tcp_md5_key_add(
@@ -190,11 +488,11 @@ pub fn tcp_md5_key_add(
     dst: SockAddr,
     authstring: &str,
     valid_time: Duration,
-) -> anyhow::Result<()> {
+) -> Result<(), Error> {
     tcp_md5_key_set(src, dst, authstring, valid_time, false)
 }
 
-/// Update a TCP-MD5 security association for the provided souce and destination
+/// Update a TCP-MD5 security association for the provided source and destination
 /// address with `authstring` as the key that is valid for `valid_time` after
 /// creation.
 pub fn tcp_md5_key_update(
@@ -202,11 +500,11 @@ pub fn tcp_md5_key_update(
     dst: SockAddr,
     authstring: &str,
     valid_time: Duration,
-) -> anyhow::Result<()> {
+) -> Result<(), Error> {
     tcp_md5_key_set(src, dst, authstring, valid_time, true)
 }
 
-/// Set a TCP-MD5 security association for the provided souce and destination
+/// Set a TCP-MD5 security association for the provided source and destination
 /// address with `authstring` as the key that is valid for `valid_time` after
 /// creation. If update is true, this is treated as an update to an existing
 /// association, otherwise a new association is created.
@@ -216,7 +514,7 @@ pub fn tcp_md5_key_set(
     authstring: &str,
     valid_time: Duration,
     update: bool,
-) -> anyhow::Result<()> {
+) -> Result<(), Error> {
     let msg =
         TcpMd5SetKeyRequest::new(src, dst, authstring, valid_time, update);
     let mut sock = Socket::new(
@@ -232,158 +530,78 @@ pub fn tcp_md5_key_set(
     };
     let n = sock.write(data)?;
     if n != data.len() {
-        return Err(anyhow::anyhow!("short write {} != {}", n, data.len()));
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            format!("short write {} != {}", n, data.len()),
+        )
+        .into());
     }
 
     let mut buf = [0u8; 1024];
     let _n = sock.read(&mut buf)?;
     let response = unsafe { &*(buf.as_ptr() as *const Header) };
 
-    let diagnostic = response.reserved;
-
-    println!(
-        "{:?}/{:?}: {}/{}",
-        response.typ, response.sa_typ, response.errno, diagnostic
-    );
+    if response.errno != 0 {
+        return Err(Error::PfKey {
+            errno: response.errno,
+            typ: response.typ,
+            sa_typ: response.sa_typ,
+            diagnostic: response.reserved,
+        });
+    }
 
     Ok(())
 }
 
-impl TcpMd5SetKeyRequest {
-    fn new(
-        src: SockAddr,
-        dst: SockAddr,
-        authstring: &str,
-        valid_time: Duration,
-        update: bool,
-    ) -> Self {
-        let header = Header {
-            version: PF_KEY_V2,
-            typ: if update {
-                MessageType::Update
-            } else {
-                MessageType::Add
-            },
-            errno: 0,
-            sa_typ: SaType::TcpSig,
-            len: u16::try_from(size_of::<Self>()).unwrap() >> 3,
-            reserved: 0,
-            seq: rand::random(),
-            pid: std::process::id(),
-        };
-
-        let association = Association {
-            len: u16::try_from(size_of::<Association>()).unwrap() >> 3,
-            typ: SaExtType::Sa,
-            spi: 0, // This is not for IPsec
-            replay: 0,
-            state: SaState::Mature,
-            auth: SaAuthType::Md5,
-            encrypt: SaEncryptType::None,
-            flags: 0,
-        };
-
-        let lifetime = Lifetime {
-            len: u16::try_from(size_of::<Lifetime>()).unwrap() >> 3,
-            typ: SaExtType::LifetimeHard,
-            alloc: 0, // no allocation limit
-            bytes: 0, // no byte limit
-            addtime: valid_time.as_secs(),
-            usetime: valid_time.as_secs(),
-        };
-
-        let src = Address {
-            len: u16::try_from(size_of::<Address>()).unwrap() >> 3,
-            typ: SaExtType::AddressSrc,
-            proto: IPPROTO_TCP as u8,
-            prefix_len: 0,
-            reserved: 0,
-            sockaddr: src,
-        };
-
-        let dst = Address {
-            len: u16::try_from(size_of::<Address>()).unwrap() >> 3,
-            typ: SaExtType::AddressDst,
-            proto: IPPROTO_TCP as u8,
-            prefix_len: 0,
-            reserved: 0,
-            sockaddr: dst,
-        };
-
-        let mut key = Key {
-            len: u16::try_from(size_of::<Key>()).unwrap() >> 3,
-            typ: SaExtType::StrAuth,
-            bits: u16::try_from(authstring.len() << 3).unwrap(),
-            reserved: 0,
-            data: [0; MAX_KEY_SIZE],
-        };
-        key.data[..authstring.len()].copy_from_slice(authstring.as_bytes());
-
-        Self {
-            header,
-            association,
-            lifetime,
-            src,
-            dst,
-            key,
-        }
+/// Get info on a TCP-MD5 security association for the provided source and
+/// destination address with
+pub fn tcp_md5_key_get(
+    src: SockAddr,
+    dst: SockAddr,
+) -> Result<GetAssociationResponse, Error> {
+    let msg = TcpMd5GetKeyRequest::new(src, dst);
+    let mut sock = Socket::new(
+        Domain::from(PF_KEY),
+        Type::RAW,
+        Some(Protocol::from(i32::from(PF_KEY_V2))),
+    )?;
+    let data = unsafe {
+        std::slice::from_raw_parts(
+            (&msg as *const TcpMd5GetKeyRequest) as *const u8,
+            size_of::<TcpMd5GetKeyRequest>(),
+        )
+    };
+    let n = sock.write(data)?;
+    if n != data.len() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            format!("short write {} != {}", n, data.len()),
+        )
+        .into());
     }
-}
 
-impl TcpMd5DeleteKeyRequest {
-    fn new(src: SockAddr, dst: SockAddr) -> Self {
-        let header = Header {
-            version: PF_KEY_V2,
-            typ: MessageType::Delete,
-            errno: 0,
-            sa_typ: SaType::TcpSig,
-            len: u16::try_from(size_of::<Self>()).unwrap() >> 3,
-            reserved: 0,
-            seq: rand::random(),
-            pid: std::process::id(),
-        };
+    let mut buf = [0u8; 1024];
+    let _n = sock.read(&mut buf)?;
+    let response = unsafe { &*(buf.as_ptr() as *const Header) };
 
-        let association = Association {
-            len: u16::try_from(size_of::<Association>()).unwrap() >> 3,
-            typ: SaExtType::Sa,
-            spi: 0, // This is not for IPsec
-            replay: 0,
-            state: SaState::Mature,
-            auth: SaAuthType::Md5,
-            encrypt: SaEncryptType::None,
-            flags: 0,
-        };
-
-        let src = Address {
-            len: u16::try_from(size_of::<Address>()).unwrap() >> 3,
-            typ: SaExtType::AddressSrc,
-            proto: IPPROTO_TCP as u8,
-            prefix_len: 0,
-            reserved: 0,
-            sockaddr: src,
-        };
-
-        let dst = Address {
-            len: u16::try_from(size_of::<Address>()).unwrap() >> 3,
-            typ: SaExtType::AddressDst,
-            proto: IPPROTO_TCP as u8,
-            prefix_len: 0,
-            reserved: 0,
-            sockaddr: dst,
-        };
-
-        Self {
-            header,
-            association,
-            src,
-            dst,
-        }
+    if response.errno != 0 {
+        return Err(Error::PfKey {
+            errno: response.errno,
+            typ: response.typ,
+            sa_typ: response.sa_typ,
+            diagnostic: response.reserved,
+        });
     }
+
+    let cursor = &mut buf.as_slice();
+    parse::association_response
+        .parse_next(cursor)
+        .map_err(|e| Error::PfKeyParse(format!("{e:?}")))
 }
 
 /// Delete the TCP-MD5 security association for the provided source and
 /// destination.
-pub fn tcp_md5_key_remove(src: SockAddr, dst: SockAddr) -> anyhow::Result<()> {
+pub fn tcp_md5_key_remove(src: SockAddr, dst: SockAddr) -> Result<(), Error> {
     let msg = TcpMd5DeleteKeyRequest::new(src, dst);
     let mut sock = Socket::new(
         Domain::from(PF_KEY),
@@ -398,18 +616,202 @@ pub fn tcp_md5_key_remove(src: SockAddr, dst: SockAddr) -> anyhow::Result<()> {
     };
     let n = sock.write(data)?;
     if n != data.len() {
-        return Err(anyhow::anyhow!("short write {} != {}", n, data.len()));
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            format!("short write {} != {}", n, data.len()),
+        )
+        .into());
     }
 
     let mut buf = [0u8; 1024];
     let _n = sock.read(&mut buf)?;
     let response = unsafe { &*(buf.as_ptr() as *const Header) };
 
-    let diagnostic = response.reserved;
+    if response.errno != 0 {
+        return Err(Error::PfKey {
+            errno: response.errno,
+            typ: response.typ,
+            sa_typ: response.sa_typ,
+            diagnostic: response.reserved,
+        });
+    }
 
-    println!(
-        "{:?}/{:?}: {}/{}",
-        response.typ, response.sa_typ, response.errno, diagnostic
-    );
     Ok(())
+}
+
+/// Errors that can be returned from PF_KEY operations.
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("io error {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("pfkey {typ:?}/{sa_typ:?} {errno}/{diagnostic}")]
+    PfKey {
+        typ: MessageType,
+        sa_typ: SaType,
+        errno: u8,
+        diagnostic: u16,
+    },
+
+    #[error("pfkey parse {0}")]
+    PfKeyParse(String),
+}
+
+mod parse {
+    use super::*;
+
+    pub fn association_response(
+        buf: &mut &[u8],
+    ) -> PResult<GetAssociationResponse> {
+        Ok(GetAssociationResponse {
+            header: header.parse_next(buf)?,
+            extensions: repeat(0.., extension).parse_next(buf)?,
+        })
+    }
+
+    pub fn header(buf: &mut &[u8]) -> PResult<Header> {
+        Ok(Header {
+            version: le_u8.parse_next(buf)?,
+            typ: parse::message_type.parse_next(buf)?,
+            errno: le_u8.parse_next(buf)?,
+            sa_typ: parse::sa_type.parse_next(buf)?,
+            len: le_u16.parse_next(buf)?,
+            reserved: le_u16.parse_next(buf)?,
+            seq: le_u32.parse_next(buf)?,
+            pid: le_u32.parse_next(buf)?,
+        })
+    }
+
+    pub fn extension(buf: &mut &[u8]) -> PResult<Extension> {
+        let len = le_u16.parse_next(buf)?;
+        let typ = parse::sa_ext_type.parse_next(buf)?;
+        println!("{typ:?}");
+        Ok(match typ {
+            SaExtType::Sa => {
+                Extension::Association(parse::association(len).parse_next(buf)?)
+            }
+            SaExtType::LifetimeCurrent
+            | SaExtType::LifetimeHard
+            | SaExtType::LifetimeSoft => {
+                Extension::Lifetime(parse::lifetime(len, typ).parse_next(buf)?)
+            }
+            SaExtType::AddressSrc | SaExtType::AddressDst => {
+                Extension::Address(parse::address(len, typ).parse_next(buf)?)
+            }
+            SaExtType::StrAuth => {
+                Extension::StrAuth(parse::str_auth(len).parse_next(buf)?)
+            }
+        })
+    }
+
+    pub fn association(
+        len: u16,
+    ) -> impl FnMut(&mut &[u8]) -> PResult<Association> {
+        move |buf: &mut &[u8]| -> PResult<Association> {
+            Ok(Association {
+                len,
+                typ: SaExtType::Sa,
+                spi: le_u32.parse_next(buf)?,
+                replay: le_u8.parse_next(buf)?,
+                state: parse::sa_state.parse_next(buf)?,
+                auth: parse::sa_auth_type.parse_next(buf)?,
+                encrypt: parse::sa_encrypt_type.parse_next(buf)?,
+                flags: le_u32.parse_next(buf)?,
+            })
+        }
+    }
+
+    pub fn lifetime(
+        len: u16,
+        typ: SaExtType,
+    ) -> impl FnMut(&mut &[u8]) -> PResult<Lifetime> {
+        move |buf: &mut &[u8]| -> PResult<Lifetime> {
+            Ok(Lifetime {
+                len,
+                typ,
+                alloc: le_u32.parse_next(buf)?,
+                bytes: le_u64.parse_next(buf)?,
+                addtime: le_u64.parse_next(buf)?,
+                usetime: le_u64.parse_next(buf)?,
+            })
+        }
+    }
+
+    pub fn address(
+        len: u16,
+        typ: SaExtType,
+    ) -> impl FnMut(&mut &[u8]) -> PResult<Address> {
+        move |buf: &mut &[u8]| -> PResult<Address> {
+            let sockaddr_len = ((len as usize) << 3)
+                - (size_of::<Address>() - size_of::<SockAddr>());
+            Ok(Address {
+                len,
+                typ,
+                proto: le_u8.parse_next(buf)?,
+                prefix_len: le_u8.parse_next(buf)?,
+                reserved: le_u16.parse_next(buf)?,
+                sockaddr: unsafe {
+                    let x = take(sockaddr_len).parse_next(buf)?;
+                    let mut buf = [0; size_of::<SockAddr>()];
+                    buf[0..sockaddr_len].copy_from_slice(x);
+                    (buf.as_ptr() as *const SockAddr).read_unaligned()
+                },
+            })
+        }
+    }
+
+    pub fn str_auth(len: u16) -> impl FnMut(&mut &[u8]) -> PResult<StrAuth> {
+        let data_len = ((len as usize) << 3)
+            - (size_of::<StrAuth>() - MAX_STR_AUTH_KEY_SIZE);
+        move |buf: &mut &[u8]| -> PResult<StrAuth> {
+            Ok(StrAuth {
+                len,
+                typ: SaExtType::StrAuth,
+                bits: le_u16.parse_next(buf)?,
+                reserved: le_u16.parse_next(buf)?,
+                data: {
+                    let x = take(data_len).parse_next(buf)?;
+                    let mut buf = [0; MAX_STR_AUTH_KEY_SIZE];
+                    buf[0..data_len].copy_from_slice(x);
+                    buf
+                },
+            })
+        }
+    }
+
+    pub fn message_type(buf: &mut &[u8]) -> PResult<MessageType> {
+        let value = le_u8.parse_next(buf)?;
+        MessageType::try_from_primitive(value)
+            .map_err(|_| ErrMode::Backtrack(ContextError::new()))
+    }
+
+    pub fn sa_type(buf: &mut &[u8]) -> PResult<SaType> {
+        let value = le_u8.parse_next(buf)?;
+        SaType::try_from_primitive(value)
+            .map_err(|_| ErrMode::Backtrack(ContextError::new()))
+    }
+
+    fn sa_ext_type(buf: &mut &[u8]) -> PResult<SaExtType> {
+        let value = le_u16.parse_next(buf)?;
+        SaExtType::try_from_primitive(value)
+            .map_err(|_| ErrMode::Backtrack(ContextError::new()))
+    }
+
+    fn sa_auth_type(buf: &mut &[u8]) -> PResult<SaAuthType> {
+        let value = le_u8.parse_next(buf)?;
+        SaAuthType::try_from_primitive(value)
+            .map_err(|_| ErrMode::Backtrack(ContextError::new()))
+    }
+
+    fn sa_encrypt_type(buf: &mut &[u8]) -> PResult<SaEncryptType> {
+        let value = le_u8.parse_next(buf)?;
+        SaEncryptType::try_from_primitive(value)
+            .map_err(|_| ErrMode::Backtrack(ContextError::new()))
+    }
+
+    fn sa_state(buf: &mut &[u8]) -> PResult<SaState> {
+        let value = le_u8.parse_next(buf)?;
+        SaState::try_from_primitive(value)
+            .map_err(|_| ErrMode::Backtrack(ContextError::new()))
+    }
 }

--- a/libnet/src/pf_key.rs
+++ b/libnet/src/pf_key.rs
@@ -111,7 +111,7 @@ pub enum SaState {
     Dead,
 }
 
-#[repr(packed)]
+#[repr(C, packed)]
 pub struct Header {
     pub version: u8,
     pub typ: MessageType,
@@ -123,7 +123,7 @@ pub struct Header {
     pub pid: u32,
 }
 
-#[repr(packed)]
+#[repr(C, packed)]
 pub struct Association {
     pub len: u16,
     pub typ: SaExtType,
@@ -135,7 +135,7 @@ pub struct Association {
     pub flags: u32,
 }
 
-#[repr(packed)]
+#[repr(C, packed)]
 pub struct Lifetime {
     pub len: u16,
     pub typ: SaExtType,
@@ -145,7 +145,7 @@ pub struct Lifetime {
     pub usetime: u64,
 }
 
-#[repr(packed)]
+#[repr(C, packed)]
 pub struct Address {
     pub len: u16,
     pub typ: SaExtType,
@@ -155,7 +155,7 @@ pub struct Address {
     pub sockaddr: SockAddr,
 }
 
-#[repr(packed)]
+#[repr(C, packed)]
 pub struct Key {
     pub len: u16,
     pub typ: SaExtType,
@@ -164,7 +164,7 @@ pub struct Key {
     pub data: [u8; MAX_KEY_SIZE],
 }
 
-#[repr(packed)]
+#[repr(C, packed)]
 pub struct TcpMd5AddKeyRequest {
     pub header: Header,
     pub association: Association,
@@ -174,7 +174,7 @@ pub struct TcpMd5AddKeyRequest {
     pub key: Key,
 }
 
-#[repr(packed)]
+#[repr(C, packed)]
 pub struct TcpMd5DeleteKeyRequest {
     pub header: Header,
     pub association: Association,

--- a/libnet/src/pf_key.rs
+++ b/libnet/src/pf_key.rs
@@ -559,6 +559,12 @@ pub fn tcp_md5_key_add(
     let response = unsafe { &*(buf.as_ptr() as *const Header) };
 
     if response.errno != 0 {
+        if response.seq != msg.header.seq {
+            return Err(Error::PfKeySequenceMismatch {
+                expected: msg.header.seq,
+                received: response.seq,
+            });
+        }
         return Err(Error::PfKey {
             errno: response.errno,
             typ: response.typ,
@@ -604,6 +610,12 @@ pub fn tcp_md5_key_update(
     let response = unsafe { &*(buf.as_ptr() as *const Header) };
 
     if response.errno != 0 {
+        if response.seq != msg.header.seq {
+            return Err(Error::PfKeySequenceMismatch {
+                expected: msg.header.seq,
+                received: response.seq,
+            });
+        }
         return Err(Error::PfKey {
             errno: response.errno,
             typ: response.typ,
@@ -690,6 +702,12 @@ pub fn tcp_md5_key_remove(src: SockAddr, dst: SockAddr) -> Result<(), Error> {
     let response = unsafe { &*(buf.as_ptr() as *const Header) };
 
     if response.errno != 0 {
+        if response.seq != msg.header.seq {
+            return Err(Error::PfKeySequenceMismatch {
+                expected: msg.header.seq,
+                received: response.seq,
+            });
+        }
         return Err(Error::PfKey {
             errno: response.errno,
             typ: response.typ,
@@ -717,6 +735,9 @@ pub enum Error {
 
     #[error("pfkey parse {0}")]
     PfKeyParse(String),
+
+    #[error("pfkey sequence mismatch {expected} {received}")]
+    PfKeySequenceMismatch { expected: u32, received: u32 },
 }
 
 mod parse {

--- a/libnet/src/pf_key.rs
+++ b/libnet/src/pf_key.rs
@@ -1,0 +1,383 @@
+// Copyright 2024 Oxide Computer Company
+
+use libc::IPPROTO_TCP;
+use socket2::{Domain, Protocol, SockAddr, Socket, Type};
+use std::io::{Read, Write};
+use std::{mem::size_of, time::Duration};
+
+const PF_KEY: i32 = 27;
+const PF_KEY_V2: u8 = 2;
+//const MAX_KEY_SIZE: usize = (u16::MAX >> 8) as usize;
+const MAX_KEY_SIZE: usize = 80;
+
+#[derive(Debug)]
+#[repr(u8)]
+pub enum MessageType {
+    Reserved = 0,
+    GetSpi = 1,
+    Update = 2,
+    Add = 3,
+    Delete = 4,
+    Get = 5,
+    Acquire = 6,
+    Register = 7,
+    Expire = 8,
+    Flush = 9,
+    Dump = 10,
+    Promisc = 11,
+    InverseAcquire = 12,
+    UpdatePair = 13,
+    DelPair = 14,
+    DelPairState = 15,
+}
+
+#[derive(Debug)]
+#[repr(u8)]
+pub enum SaType {
+    Unspec = 0,
+    Ah = 2,
+    Esp = 3,
+    TcpSig = 4,
+    Rsvp = 5,
+    OspvV2 = 6,
+    RipV2 = 7,
+    Mip = 8,
+}
+
+#[repr(u16)]
+pub enum SaExtType {
+    Sa = 1,
+    LifetimeCurrent = 2,
+    LifetimeHard = 3,
+    LifetimeSoft = 4,
+    AddressSrc = 5,
+    AddressDst = 6,
+    AddressProxy = 7,
+    KeyAuth = 8,
+    KeyEncrypt = 9,
+    IdentitySrc = 10,
+    IdentityDst = 11,
+    Sensitivity = 12,
+    Proposal = 13,
+    SupportedAuth = 14,
+    SupportedEncrypt = 15,
+    SpiRange = 16,
+    Ereg = 17,
+    Eprop = 18,
+    KmCookie = 19,
+    AddressNattLoc = 20,
+    AddressNattRem = 21,
+    AddressInnerDst = 22,
+    Pair = 23,
+    ReplayValue = 24,
+    Edump = 25,
+    LifetimeIdle = 26,
+    OuterSens = 27,
+    StrAuth = 28,
+}
+
+#[repr(u8)]
+pub enum SaAuthType {
+    None,
+    Md5,
+    Md5Hmac,
+    Sha1Hmac,
+    Sha256Hmac,
+    Sha384Hmac,
+    Sha512Hmac,
+}
+
+#[repr(u8)]
+pub enum SaEncryptType {
+    None,
+    DesCbc,
+    DesCbc3,
+    Blowfish,
+    Null,
+    Aes,
+    AesCcm8,
+    AesCcm12,
+    AesCcm16,
+    AesGcm8,
+    AesGcm12,
+    AesGcm16,
+}
+
+#[repr(u8)]
+pub enum SaState {
+    Larval,
+    Mature,
+    Dying,
+    Dead,
+}
+
+#[repr(packed)]
+pub struct Header {
+    pub version: u8,
+    pub typ: MessageType,
+    pub errno: u8,
+    pub sa_typ: SaType,
+    pub len: u16,
+    pub reserved: u16,
+    pub seq: u32,
+    pub pid: u32,
+}
+
+#[repr(packed)]
+pub struct Association {
+    pub len: u16,
+    pub typ: SaExtType,
+    pub spi: u32,
+    pub replay: u8,
+    pub state: SaState,
+    pub auth: SaAuthType,
+    pub encrypt: SaEncryptType,
+    pub flags: u32,
+}
+
+#[repr(packed)]
+pub struct Lifetime {
+    pub len: u16,
+    pub typ: SaExtType,
+    pub alloc: u32,
+    pub bytes: u64,
+    pub addtime: u64,
+    pub usetime: u64,
+}
+
+#[repr(packed)]
+pub struct Address {
+    pub len: u16,
+    pub typ: SaExtType,
+    pub proto: u8,
+    pub prefix_len: u8,
+    pub reserved: u16,
+    pub sockaddr: SockAddr,
+}
+
+#[repr(packed)]
+pub struct Key {
+    pub len: u16,
+    pub typ: SaExtType,
+    pub bits: u16,
+    pub reserved: u16,
+    pub data: [u8; MAX_KEY_SIZE],
+}
+
+#[repr(packed)]
+pub struct TcpMd5AddKeyRequest {
+    pub header: Header,
+    pub association: Association,
+    pub lifetime: Lifetime,
+    pub src: Address,
+    pub dst: Address,
+    pub key: Key,
+}
+
+#[repr(packed)]
+pub struct TcpMd5DeleteKeyRequest {
+    pub header: Header,
+    pub association: Association,
+    pub src: Address,
+    pub dst: Address,
+}
+
+/// Add a TCP-MD5 security association for the provided souce and destination
+/// address with `authstring` as the key that is valid for `valid_time` after
+/// creation.
+pub fn tcp_md5_key_add(
+    src: SockAddr,
+    dst: SockAddr,
+    authstring: &str,
+    valid_time: Duration,
+) -> anyhow::Result<()> {
+    let msg = TcpMd5AddKeyRequest::new(src, dst, authstring, valid_time);
+    let mut sock = Socket::new(
+        Domain::from(PF_KEY),
+        Type::RAW,
+        Some(Protocol::from(i32::from(PF_KEY_V2))),
+    )?;
+    let data = unsafe {
+        std::slice::from_raw_parts(
+            (&msg as *const TcpMd5AddKeyRequest) as *const u8,
+            size_of::<TcpMd5AddKeyRequest>(),
+        )
+    };
+    let n = sock.write(data)?;
+    if n != data.len() {
+        return Err(anyhow::anyhow!("short write {} != {}", n, data.len()));
+    }
+
+    let mut buf = [0u8; 1024];
+    let _n = sock.read(&mut buf)?;
+    let response = unsafe { &*(buf.as_ptr() as *const Header) };
+
+    let diagnostic = response.reserved;
+
+    println!(
+        "{:?}/{:?}: {}/{}",
+        response.typ, response.sa_typ, response.errno, diagnostic
+    );
+
+    Ok(())
+}
+
+impl TcpMd5AddKeyRequest {
+    fn new(
+        src: SockAddr,
+        dst: SockAddr,
+        authstring: &str,
+        valid_time: Duration,
+    ) -> Self {
+        let header = Header {
+            version: PF_KEY_V2,
+            typ: MessageType::Add,
+            errno: 0,
+            sa_typ: SaType::TcpSig,
+            len: u16::try_from(size_of::<Self>()).unwrap() >> 3,
+            reserved: 0,
+            seq: rand::random(),
+            pid: std::process::id(),
+        };
+
+        let association = Association {
+            len: u16::try_from(size_of::<Association>()).unwrap() >> 3,
+            typ: SaExtType::Sa,
+            spi: 0, // This is not for IPsec
+            replay: 0,
+            state: SaState::Mature,
+            auth: SaAuthType::Md5,
+            encrypt: SaEncryptType::None,
+            flags: 0,
+        };
+
+        let lifetime = Lifetime {
+            len: u16::try_from(size_of::<Lifetime>()).unwrap() >> 3,
+            typ: SaExtType::LifetimeHard,
+            alloc: 0, // no allocation limit
+            bytes: 0, // no byte limit
+            addtime: valid_time.as_secs(),
+            usetime: valid_time.as_secs(),
+        };
+
+        let src = Address {
+            len: u16::try_from(size_of::<Address>()).unwrap() >> 3,
+            typ: SaExtType::AddressSrc,
+            proto: IPPROTO_TCP as u8,
+            prefix_len: 0,
+            reserved: 0,
+            sockaddr: src,
+        };
+
+        let dst = Address {
+            len: u16::try_from(size_of::<Address>()).unwrap() >> 3,
+            typ: SaExtType::AddressDst,
+            proto: IPPROTO_TCP as u8,
+            prefix_len: 0,
+            reserved: 0,
+            sockaddr: dst,
+        };
+
+        let mut key = Key {
+            len: u16::try_from(size_of::<Key>()).unwrap() >> 3,
+            typ: SaExtType::StrAuth,
+            bits: u16::try_from(authstring.len() << 3).unwrap(),
+            reserved: 0,
+            data: [0; MAX_KEY_SIZE],
+        };
+        key.data[..authstring.len()].copy_from_slice(authstring.as_bytes());
+
+        Self {
+            header,
+            association,
+            lifetime,
+            src,
+            dst,
+            key,
+        }
+    }
+}
+
+impl TcpMd5DeleteKeyRequest {
+    fn new(src: SockAddr, dst: SockAddr) -> Self {
+        let header = Header {
+            version: PF_KEY_V2,
+            typ: MessageType::Delete,
+            errno: 0,
+            sa_typ: SaType::TcpSig,
+            len: u16::try_from(size_of::<Self>()).unwrap() >> 3,
+            reserved: 0,
+            seq: rand::random(),
+            pid: std::process::id(),
+        };
+
+        let association = Association {
+            len: u16::try_from(size_of::<Association>()).unwrap() >> 3,
+            typ: SaExtType::Sa,
+            spi: 0, // This is not for IPsec
+            replay: 0,
+            state: SaState::Mature,
+            auth: SaAuthType::Md5,
+            encrypt: SaEncryptType::None,
+            flags: 0,
+        };
+
+        let src = Address {
+            len: u16::try_from(size_of::<Address>()).unwrap() >> 3,
+            typ: SaExtType::AddressSrc,
+            proto: IPPROTO_TCP as u8,
+            prefix_len: 0,
+            reserved: 0,
+            sockaddr: src,
+        };
+
+        let dst = Address {
+            len: u16::try_from(size_of::<Address>()).unwrap() >> 3,
+            typ: SaExtType::AddressDst,
+            proto: IPPROTO_TCP as u8,
+            prefix_len: 0,
+            reserved: 0,
+            sockaddr: dst,
+        };
+
+        Self {
+            header,
+            association,
+            src,
+            dst,
+        }
+    }
+}
+
+/// Delete the TCP-MD5 security association for the provided source and
+/// destination.
+pub fn tcp_md5_key_remove(src: SockAddr, dst: SockAddr) -> anyhow::Result<()> {
+    let msg = TcpMd5DeleteKeyRequest::new(src, dst);
+    let mut sock = Socket::new(
+        Domain::from(PF_KEY),
+        Type::RAW,
+        Some(Protocol::from(i32::from(PF_KEY_V2))),
+    )?;
+    let data = unsafe {
+        std::slice::from_raw_parts(
+            (&msg as *const TcpMd5DeleteKeyRequest) as *const u8,
+            size_of::<TcpMd5DeleteKeyRequest>(),
+        )
+    };
+    let n = sock.write(data)?;
+    if n != data.len() {
+        return Err(anyhow::anyhow!("short write {} != {}", n, data.len()));
+    }
+
+    let mut buf = [0u8; 1024];
+    let _n = sock.read(&mut buf)?;
+    let response = unsafe { &*(buf.as_ptr() as *const Header) };
+
+    let diagnostic = response.reserved;
+
+    println!(
+        "{:?}/{:?}: {}/{}",
+        response.typ, response.sa_typ, response.errno, diagnostic
+    );
+    Ok(())
+}

--- a/netadm/src/main.rs
+++ b/netadm/src/main.rs
@@ -3,7 +3,9 @@
 use anyhow::{anyhow, Result};
 use clap::{Parser, ValueEnum};
 use colored::*;
-use libnet::pf_key::{tcp_md5_key_get, tcp_md5_key_remove, tcp_md5_key_set};
+use libnet::pf_key::{
+    tcp_md5_key_add, tcp_md5_key_get, tcp_md5_key_remove, tcp_md5_key_update,
+};
 use libnet::{
     self, add_route, create_ipaddr, create_simnet_link, create_tfport_link,
     create_vnic_link, get_ipaddr_info, get_ipaddrs, get_link, get_links, ip,
@@ -480,13 +482,16 @@ fn create_route(_opts: &Opts, _c: &Create, c: &CreateRoute) -> Result<()> {
 }
 
 fn create_tcp_md5(_opts: &Opts, _c: &Create, c: &CreateTcpMd5) -> Result<()> {
-    tcp_md5_key_set(
-        c.src.into(),
-        c.dst.into(),
-        &c.authstring,
-        c.valid_time.into(),
-        c.update,
-    )?;
+    if c.update {
+        tcp_md5_key_update(c.src.into(), c.dst.into(), c.valid_time.into())?;
+    } else {
+        tcp_md5_key_add(
+            c.src.into(),
+            c.dst.into(),
+            &c.authstring,
+            c.valid_time.into(),
+        )?;
+    }
     Ok(())
 }
 

--- a/netadm/src/main.rs
+++ b/netadm/src/main.rs
@@ -3,7 +3,7 @@
 use anyhow::{anyhow, Result};
 use clap::{Parser, ValueEnum};
 use colored::*;
-use libnet::pf_key::{tcp_md5_key_add, tcp_md5_key_remove};
+use libnet::pf_key::{tcp_md5_key_remove, tcp_md5_key_set};
 use libnet::{
     self, add_route, create_ipaddr, create_simnet_link, create_tfport_link,
     create_vnic_link, get_ipaddr_info, get_ipaddrs, get_link, get_links, ip,
@@ -216,6 +216,9 @@ struct CreateTcpMd5 {
     authstring: String,
     /// How long the association is valid for
     valid_time: humantime::Duration,
+    /// Treat this as an update instead of a create
+    #[clap(long)]
+    update: bool,
 }
 
 #[derive(Parser)]
@@ -463,11 +466,12 @@ fn create_route(_opts: &Opts, _c: &Create, c: &CreateRoute) -> Result<()> {
 }
 
 fn create_tcp_md5(_opts: &Opts, _c: &Create, c: &CreateTcpMd5) -> Result<()> {
-    tcp_md5_key_add(
+    tcp_md5_key_set(
         c.src.into(),
         c.dst.into(),
         &c.authstring,
         c.valid_time.into(),
+        c.update,
     )?;
     Ok(())
 }


### PR DESCRIPTION
This PR provides enough PF_KEY support for the management of TCP-MD5 keys on illumos. A complete PF_KEY implementation with all extension types is not the intent of this PR, but it should provide a good foundation for working toward that.

- Fixes #30

There 4 primary top level functions added to the libnet API.

- `tcp_md5_key_add`
- `tcp_md5_key_update`
- `tcp_md4_key_get`
- `tcp_md5_key_remove`

### References
- Docs: https://oxidecomputer.github.io/netadm-sys/libnet/pf_key/index.html
- RFC: https://datatracker.ietf.org/doc/html/rfc2367
- PF_KEY(4P): https://illumos.org/man/4P/pf_key